### PR TITLE
Added support for 4ch relay fan controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# IDEs
+.vscode/
+
 # yarn v2
 
 .yarn/cache

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "HDLBuspro",
   "name": "homebridge-hdl-buspro",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Linking the HDL bus into the Homebridge widget",
   "license": "Apache-2.0",
   "repository": {

--- a/src/DeviceList.ts
+++ b/src/DeviceList.ts
@@ -11,6 +11,7 @@ import { OccupancySensor } from './OccupancySensor';
 import { ContactSensor, DryListener } from './ContactSensor';
 import { RelayCurtains, RelayCurtainListener } from './RelayCurtains';
 import { RelayCurtainValve } from './RelayCurtainValve';
+import { RelayFan } from './RelayFan';
 
 export interface DeviceType<T extends ABCDevice, U extends ABCListener> {
   deviceClass: new (...args: any[]) => T;
@@ -29,6 +30,13 @@ export const deviceTypeMap: {[key: string]: DeviceType<any, any>} = {
   },
   'relaydimmablelightbulb': {
     deviceClass: RelayDimmableLightbulb,
+    listener: RelayListener,
+    uniqueArgs: (config) => [config.channel],
+    idEnding: (config) => `${config.channel}`,
+  },
+  // Fan support
+  'relayfan': {
+    deviceClass: RelayFan,
     listener: RelayListener,
     uniqueArgs: (config) => [config.channel],
     idEnding: (config) => `${config.channel}`,

--- a/src/RelayFan.ts
+++ b/src/RelayFan.ts
@@ -1,0 +1,103 @@
+import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { Device } from 'smart-bus';
+import { HDLBusproHomebridge } from './HDLPlatform';
+import { ABCDevice } from './ABC';
+import { RelayListener } from './RelayLightbulb';
+
+export class RelayFan implements ABCDevice {
+  private service: Service;
+  private RelayFanStates = {
+    On: false,
+    Speed: 0,
+  };
+
+  constructor(
+    private readonly platform: HDLBusproHomebridge,
+    private readonly accessory: PlatformAccessory,
+    private readonly name: string,
+    private readonly controller: Device,
+    private readonly device: Device,
+    private readonly listener: RelayListener,
+    private readonly channel: number,
+  ) {
+    const Service = this.platform.Service;
+    const Characteristic = this.platform.Characteristic;
+    this.accessory.getService(Service.AccessoryInformation)!
+      .setCharacteristic(Characteristic.Manufacturer, 'HDL');
+    this.service = this.accessory.getService(Service.Fan) || this.accessory.addService(Service.Fan);
+    this.service.setCharacteristic(Characteristic.Name, name);
+    this.service.getCharacteristic(Characteristic.On)
+      .onSet(this.setOn.bind(this))
+      .onGet(this.getOn.bind(this));
+    this.service.getCharacteristic(Characteristic.RotationSpeed)
+      .onSet(this.setSpeed.bind(this))
+      .onGet(this.getSpeed.bind(this));
+
+    const eventEmitter = this.listener.getChannelEventEmitter(this.channel);
+    eventEmitter.on('update', (level) => {
+      this.RelayFanStates.On = (level > 0);
+      this.RelayFanStates.Speed = this.mapHDLSpeedToHomebridge(level);
+      this.service.getCharacteristic(Characteristic.On).updateValue(this.RelayFanStates.On);
+      this.service.getCharacteristic(Characteristic.RotationSpeed).updateValue(this.RelayFanStates.Speed);
+      if (this.RelayFanStates.On) {
+        this.platform.log.debug(this.name + ' is now on with speed ' + this.RelayFanStates.Speed);
+      } else {
+        this.platform.log.debug(this.name + ' is now off');
+      }
+    });
+  }
+
+  async setOn(value: CharacteristicValue) {
+    const oldValue = this.RelayFanStates.On;
+    this.RelayFanStates.On = value as boolean;
+    this.controller.send({
+      target: this.device,
+      command: 0x0031,
+      data: { channel: this.channel, level: this.RelayFanStates.On ? this.mapHomebridgeSpeedToHDL(this.RelayFanStates.Speed) : 0 },
+    }, (err) => {
+      if (err) {
+        this.RelayFanStates.On = oldValue;
+        this.platform.log.error(`Error setting On state for ${this.name}: ${err.message}`);
+      } else {
+        this.platform.log.debug('Successfully sent command to ' + this.name);
+      }
+    });
+  }
+
+  async setSpeed(value: CharacteristicValue) {
+    const oldSpeed = this.RelayFanStates.Speed;
+    this.RelayFanStates.Speed = value as number;
+    if (this.RelayFanStates.On) {
+      this.controller.send({
+        target: this.device,
+        command: 0x0031,
+        data: { channel: this.channel, level: this.mapHomebridgeSpeedToHDL(this.RelayFanStates.Speed) },
+      }, (err) => {
+        if (err) {
+          this.RelayFanStates.Speed = oldSpeed;
+          this.platform.log.error(`Error setting speed for ${this.name}: ${err.message}`);
+        } else {
+          this.platform.log.debug('Successfully sent speed command to ' + this.name);
+        }
+      });
+    }
+  }
+
+  async getOn(): Promise<CharacteristicValue> {
+    return this.RelayFanStates.On;
+  }
+
+  async getSpeed(): Promise<CharacteristicValue> {
+    return this.RelayFanStates.Speed;
+  }
+
+  // Function to map Homebridge values (0-100) to HDL values (0-10)
+  private mapHomebridgeSpeedToHDL(value: number): number {
+    return Math.round(value / 10);
+  }
+
+  // Function to map HDL values (0-10) to Homebridge values (0-100)
+  private mapHDLSpeedToHomebridge(value: number): number {
+    return Math.round(value * 10);
+  }
+}


### PR DESCRIPTION
# Added support for 4ch relay fan controller

As requested in #13 . 

Adding device with `device_type` set to relayfan will reflect as a fan in Homebridge and Homekit. Speed can be varied between 0-100% (Speed is rounded down to the nearest tenth to support HDL Fan controller values between 0-10)

Example config 
```json
{
    "buses": [
        {
            "subnets": [
                {
                    "subnet_number": 1,
                    "cd_number": 253,
                    "devices": [{
                            "device_name": "Living Fan",
                            "device_address": 5,
                            "device_type": "relayfan",
                            "area": 1,
                            "channel": 1,
                            "nc": true,
                            "curtains_precision": 5
                        },
                        {
                            "device_name": "Master Fan",
                            "device_address": 5,
                            "device_type": "relayfan",
                            "area": 1,
                            "channel": 3,
                            "nc": true,
                            "curtains_precision": 5
                        }
                    ]
                }
            ],
            "bus_IP": "10.0.1.20",
            "bus_port": 6000
        }
    ],
    "platform": "HDLBusproHomebridge"
}
```